### PR TITLE
Fix Tag Manager registration on Umbraco 17.3 by using backofficeEntryPoint

### DIFF
--- a/TagManager/Client/public/umbraco-package.json
+++ b/TagManager/Client/public/umbraco-package.json
@@ -8,7 +8,7 @@
 		{
 			"name": "Tag Manager EntryPoint",
 			"alias": "tagmanager.entrypoint",
-			"type": "entryPoint",
+			"type": "backofficeEntryPoint",
 			"js": "/App_Plugins/TagManager/tagmanager.js"
 		}
 	]

--- a/TagManager/wwwroot/App_Plugins/TagManager/umbraco-package.json
+++ b/TagManager/wwwroot/App_Plugins/TagManager/umbraco-package.json
@@ -8,7 +8,7 @@
 		{
 			"name": "Tag Manager EntryPoint",
 			"alias": "tagmanager.entrypoint",
-			"type": "entryPoint",
+			"type": "backofficeEntryPoint",
 			"js": "/App_Plugins/TagManager/tagmanager.js"
 		}
 	]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace deprecated `entryPoint` extension type with `backofficeEntryPoint`
- update both package manifests used by the client source and published static assets

## Why
Umbraco 17.3 deprecates `entryPoint`, which prevents the Tag Manager backoffice entry script from executing. As a result, the section/tree/workspaces are never registered.

## Changes
- `TagManager/Client/public/umbraco-package.json`
- `TagManager/wwwroot/App_Plugins/TagManager/umbraco-package.json`

## Validation
- Code update only (build verification follows in subsequent commit if needed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ae5249d-8ef8-4f45-a702-f5b42df6b82d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ae5249d-8ef8-4f45-a702-f5b42df6b82d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

