### PR TITLE
docs: add release notes for Umbraco 17.3 entry point fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ The tree is split into separate branches for each tag group created, which is us
 
 # TagManager release notes
 
+## 17.0.8
+
+### Backoffice (client)
+
+- **Umbraco 17.3+ compatibility**: Package manifest entry point registration now uses **`backofficeEntryPoint`** instead of deprecated **`entryPoint`**.
+- Restores backoffice initialization so the **Tag Manager section, tree, and workspaces** register and appear correctly.
+
+---
+
 ## 17.0.7
 
 ### Backoffice (client)

--- a/TagManager/RELEASE_NOTES.md
+++ b/TagManager/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # TagManager release notes
 
+## 17.0.8
+
+### Backoffice (client)
+
+- **Umbraco 17.3+ compatibility**: Package manifest entry point registration now uses **`backofficeEntryPoint`** instead of deprecated **`entryPoint`**.
+- Restores backoffice initialization so the **Tag Manager section, tree, and workspaces** register and appear correctly.
+
+---
+
 ## 17.0.7
 
 ### Backoffice (client)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new `17.0.8` release note section in `TagManager/RELEASE_NOTES.md`
- mirror the same `17.0.8` note in the README release-notes section
- document that the package now uses `backofficeEntryPoint` (instead of deprecated `entryPoint`) to restore Tag Manager section/tree/workspace registration on Umbraco 17.3+

## Testing
- docs-only change (no runtime code changes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fedb984c-b33e-4933-9c65-9b49932f8088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fedb984c-b33e-4933-9c65-9b49932f8088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

